### PR TITLE
feat: add formspree.io icon

### DIFF
--- a/vectors/formspree.io/formspree.svg
+++ b/vectors/formspree.io/formspree.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 63.7 64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g id="g10" transform="matrix(0.350063,0,0,0.350063,0,-1.2e-07)">
+        <ellipse id="ellipse6" cx="90.933" cy="91.412" rx="90.933" ry="91.412" style="fill:rgb(196,0,26);"/>
+        <path id="path8" d="M49.6,46.083L132.266,46.083L132.266,71.013L49.6,71.013L49.6,46.083ZM49.6,79.324L132.266,79.324L132.266,104.254L49.6,104.254L49.6,79.324ZM49.6,112.565L90.933,112.565L90.933,137.495L49.6,137.495L49.6,112.565Z" style="fill:rgb(227,227,218);"/>
+    </g>
+</svg>


### PR DESCRIPTION
Formspree recently added 2FA, at last!

Sadly, I couldn't find the "modern" icon that they are currently using. So for now, I'm adding the previous one.