### PR TITLE
Added beyond-hd icon

### DIFF
--- a/vectors/beyond-hd.me/beyond-hd.svg
+++ b/vectors/beyond-hd.me/beyond-hd.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1"  viewBox="0 0 256 256" xml:space="preserve">
+  <defs>
+  </defs>
+  <g transform="matrix(7.86 0 0 7.86 128.1 128.1)" id="_TNo8n_hSlSXtAIFoHjh5">
+    <path style="stroke: rgb(77,254,233); stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(70,112,236); fill-rule: nonzero; opacity: 1;" vector-effect="non-scaling-stroke" transform=" translate(0, 0)" d="M 0 -16.28664 C 8.99023 -16.28664 16.28664 -8.990219999999997 16.28664 0 C 16.28664 8.99023 8.990219999999997 16.28664 0 16.28664 C -8.99023 16.28664 -16.28664 8.990219999999997 -16.28664 0 C -16.28664 -8.99023 -8.990219999999997 -16.28664 0 -16.28664 z" stroke-linecap="round" />
+  </g>
+  <g transform="matrix(4.34 0 0 4.34 128 128)" id="UAFm0FR-GhbFwtJl9SF3H">
+    <path style="stroke: rgb(102,237,33); stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,255,255); fill-rule: nonzero; opacity: 1;" vector-effect="non-scaling-stroke" transform=" translate(-15.49, -14.73)" d="M 15.48952 0 L 20.084580000000003 9.96208 L 30.979040000000005 11.25379 L 22.924490000000006 18.70241 L 25.062570000000004 29.46281 L 15.489520000000004 24.10423 L 5.916470000000004 29.46281 L 8.054550000000004 18.70241 L 3.552713678800501e-15 11.25379 L 10.894460000000004 9.96208 z" stroke-linecap="round" />
+  </g>
+</svg>
+    


### PR DESCRIPTION
# Requirements

> Go over all the following points, and put an `x` in all the boxes that apply.

- [x] My issuer icon(s) are fully vector and do not contain (parts of) a JPG/PNG/etc.
- [x] My issuer icon(s) are somewhat square, so they are nicely visible in the app.
- [x] My issuer icon(s) start and end with the `<svg>` element.
- [x] My issuer icon(s) are scalable (they use `viewBox` instead of a static width/height).
- [x] My issuer icon(s) do not contain whitespace around the SVG ([this](https://jsfiddle.net/u9x423ph/2/) JSFiddle could help to remove whitespace).
- [x] My issuer icon(s) do not include the `doctype` element.
- [x] My issuer icon(s) directory and file names are lowercase.
- [x] My issuer icon(s) directory and file are in the `vectors/` folder.
