### PR TITLE
Add fennoa.com

### DIFF
--- a/vectors/fennoa.com/fennoa.svg
+++ b/vectors/fennoa.com/fennoa.svg
@@ -1,0 +1,8 @@
+<svg viewBox="9 0 719 736" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(0.1,0,0,-0.1,0,736)">
+        <path d="M5494,7360C5494,7360 5498,4504 5498,4502C5501,4496 7267,6680 7272,6680C7276,6680 7280,7360 7280,7360L5494,7360Z" style="fill:rgb(0,183,243);fill-rule:nonzero;"/>
+        <path d="M3347,6362C3332,6360 3322,6354 3325,6349C3329,6344 3331,1875 3331,1875C3331,1875 5060,3970 5066,3979C5074,3991 5075,6363 5075,6363C5075,6363 3363,6364 3347,6362Z" style="fill:rgb(0,183,243);fill-rule:nonzero;"/>
+        <path d="M7275,6274L3329,1411C3329,1411 90,3199 90,3182C90,3160 3331,-1 3331,-1L7280,3745L7275,6274Z" style="fill:rgb(95,157,44);fill-rule:nonzero;"/>
+        <path d="M1130,5315C1130,5315 1133,2996 1143,2986C1149,2980 2892,2009 2900,2005C2913,2000 2912,5310 2905,5311C2900,5312 1130,5315 1130,5315Z" style="fill:rgb(0,183,243);fill-rule:nonzero;"/>
+    </g>
+</svg>


### PR DESCRIPTION
# Requirements

> Go over all the following points, and put an `x` in all the boxes that apply.

- [x] My issuer icon(s) are fully vector and do not contain (parts of) a JPG/PNG/etc.
- [x] My issuer icon(s) are somewhat square, so they are nicely visible in the app.
- [x] My issuer icon(s) start and end with the `<svg>` element.
- [x] My issuer icon(s) are scalable (they use `viewBox` instead of a static width/height).
- [x] My issuer icon(s) do not contain whitespace around the SVG ([this](https://jsfiddle.net/u9x423ph/2/) JSFiddle could help to remove whitespace).
- [x] My issuer icon(s) do not include the `doctype` element.
- [x] My issuer icon(s) directory and file names are lowercase.
- [x] My issuer icon(s) directory and file are in the `vectors/` folder.

From https://fennoa.com/wp-content/themes/fennoa/dist/images/favicon/safari-pinned-tab.svg, that favicon is horrible so I cleaned it up a bit but it's still not awesome