### PR TITLE
Add purelymail svg

### DIFF
--- a/vectors/purelymail.com/purelymail.svg
+++ b/vectors/purelymail.com/purelymail.svg
@@ -1,0 +1,32 @@
+<svg version="1.1" viewBox="0 0 192 192" xmlns="http://www.w3.org/2000/svg">
+ <!-- Created with SVG-edit - https://github.com/SVG-Edit/svgedit-->
+ <g class="layer">
+  <title>Layer 3</title>
+  <g fill="#fff" stroke-width="12">
+   <path d="m5.5215 15.814 183.41-0.32765-2.4877 153.97-182.2 2.8554 1.2808-156.49z" stroke="#4c4c4c" stroke-dasharray="null" stroke-linecap="null" stroke-linejoin="null"/>
+   <polygon points=""/>
+   <polygon points=""/>
+   <polygon points=""/>
+   <polygon points=""/>
+   <polygon points=""/>
+   <polygon points=""/>
+   <polygon points=""/>
+   <polygon points=""/>
+   <polygon points=""/>
+  </g>
+  <line x1="7.9433" x2="71.68" y1="168.39" y2="119.44" fill="none" stroke="#ccc" stroke-dasharray="null" stroke-linecap="null" stroke-linejoin="null" stroke-width="9"/>
+  <line x1="182.61" x2="118.87" y1="165.46" y2="117.79" fill="none" stroke="#ccc" stroke-dasharray="null" stroke-linecap="null" stroke-linejoin="null" stroke-width="9"/>
+ </g>
+ <g class="layer">
+  <title>Layer 2</title>
+  <path d="m1.5148 13.947 92.308 134.94 97.655-134.45-189.96-0.48927z" fill="#fff" stroke="#310035" stroke-dasharray="null" stroke-linecap="null" stroke-linejoin="null" stroke-width="9"/>
+ </g>
+ <g class="layer">
+  <title>Layer 5</title>
+  <g stroke="#000" stroke-dasharray="null" stroke-linecap="null" stroke-linejoin="null">
+   <circle cx="94.512" cy="64.888" r="45.948" fill="#ed9ff4" stroke-width="2"/>
+   <circle cx="94.512" cy="67.416" r="27.421" stroke-width="2"/>
+   <circle transform="matrix(2.3648 .46028 -.43793 2.4855 -222.71 -98.714)" cx="133.07" cy="38.13" r="2.2361" fill="#fff" stroke-width="0"/>
+  </g>
+ </g>
+</svg>


### PR DESCRIPTION
# Requirements

- [x] My issuer icon(s) are fully vector and do not contain (parts of) a JPG/PNG/etc.
- [x] My issuer icon(s) are somewhat square, so they are nicely visible in the app.
- [x] My issuer icon(s) start and end with the `<svg>` element.
- [x] My issuer icon(s) are scalable (they use `viewBox` instead of a static width/height).
- [x] My issuer icon(s) do not contain whitespace around the SVG ([this](https://jsfiddle.net/u9x423ph/2/) JSFiddle could help to remove whitespace).
- [x] My issuer icon(s) do not include the `doctype` element.
- [x] My issuer icon(s) directory and file names are lowercase.
- [x] My issuer icon(s) directory and file are in the `vectors/` folder.
