### PR TITLE
Add phabricator icon

### DIFF
--- a/vectors/phacility.com/phacility-phabricator.svg
+++ b/vectors/phacility.com/phacility-phabricator.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-150 -150 300 300">
+<path d="m0 87.5c-66 0-117.5-54.5-139-87.5 21.5-33 73-87.5 139-87.5s117.5 54.5 139 87.5c-21.5 33-73 87.5-139 87.5z" stroke="#396" stroke-width="16" fill="#fff"/>
+<circle stroke-width="19" stroke="#069" r="47.5" fill="none"/>
+<g id="a">
+	<g id="b">
+		<g id="c" fill="#069">
+			<path id="e" d="m7.2-47-1.2-21h-12l-1.236 21"/>
+			<use xlink:href="#e" transform="scale(1,-1)"/>
+		</g>
+		<use xlink:href="#c" transform="rotate(90)"/>
+	</g>
+	<use xlink:href="#b" transform="rotate(45)"/>
+</g>
+<use xlink:href="#a" transform="rotate(22.5)"/>
+<circle r="23" fill="#900"/>
+</svg>


### PR DESCRIPTION
# Requirements

> Go over all the following points, and put an `x` in all the boxes that apply.

- [x] My issuer icon(s) are fully vector and do not contain (parts of) a JPG/PNG/etc.
- [x] My issuer icon(s) contain the original brand logo, not that from an icon pack.
- [x] My issuer icon(s) are somewhat square, so they are nicely visible in the app.
- [x] My issuer icon(s) start and end with the `<svg>` element.
- [x] My issuer icon(s) are scalable (they use `viewBox` instead of a static width/height).
- [x] My issuer icon(s) do not contain whitespace around the SVG ([this](https://jsfiddle.net/u9x423ph/2/) JSFiddle could help to remove whitespace).
- [x] My issuer icon(s) do not include the `doctype` element.
- [x] My issuer icon(s) directory and file names are lowercase.
- [x] My issuer icon(s) directory and file are in the `vectors/` folder.
