### PR TITLE
feat(icons): Add Offensity.com icon

### DIFF
--- a/vectors/offensity.com/offensity.svg
+++ b/vectors/offensity.com/offensity.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 192 192" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M112.115 5.81818H76.0497V114.67H112.115V5.81818Z" fill="#181716"/>
+<path d="M112.67 146.828H75.6364V184.01H112.67V146.828Z" fill="#DA291C"/>
+</svg>


### PR DESCRIPTION
# Requirements

> Go over all the following points, and put an `x` in all the boxes that apply.

- [X] My issuer icon is fully vector and does not contain (parts of) a JPG/PNG/etc.
- [X] My issuer icon contains the original brand logo, not that from an icon pack.
- [X] My issuer icon is somewhat square, so it's nicely visible in the app.
- [X] My issuer icon starts and ends with the `<svg>` element.
- [X] My issuer icon is scalable (it uses `viewBox` instead of a static width/height).
- [X] My issuer icon does not contain whitespace around the SVG ([this](https://jsfiddle.net/u9x423ph/2/) JSFiddle could help to remove whitespace).
- [X] My issuer icon does not include the `doctype` element.
- [X] My issuer icon directory and file name is lowercase.
- [X] My issuer icon directory and file are in the `vectors/[domain name]/` folder.
- [X] My pull request contains just one icon.
