### PR TITLE
add Gleam.io icon

### DIFF
--- a/vectors/gleam.io/gleam.svg
+++ b/vectors/gleam.io/gleam.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 170 170">
+  <path fill="#6AC3E2" d="M49.792 0 0 49.792 85 85z"/>
+  <path fill="#6E9FD4" d="M120.208 0H49.792L85 85z"/>
+  <path fill="#F2852F" d="M120.208 170 170 120.208 85 85z"/>
+  <path fill="#F1C32E" d="M49.792 170h70.416L85 85z"/>
+  <path fill="#CBDC37" d="M0 120.208 49.792 170 85 85z"/>
+  <path fill="#B5D66D" d="M0 49.792v70.416L85 85z"/>
+  <path fill="#F26A21" d="M170 120.208V49.792L85 85z"/>
+</svg>


### PR DESCRIPTION
# Requirements

> Go over all the following points, and put an `x` in all the boxes that apply.

- [x] My issuer icon is fully vector and does not contain (parts of) a JPG/PNG/etc.
- [x] My issuer icon contains the original brand logo, not that from an icon pack.
- [x] My issuer icon is somewhat square, so it's nicely visible in the app.
- [x] My issuer icon starts and ends with the `<svg>` element.
- [x] My issuer icon is scalable (it uses `viewBox` instead of a static width/height).
- [x] My issuer icon does not contain whitespace around the SVG ([this](https://jsfiddle.net/u9x423ph/2/) JSFiddle could help to remove whitespace).
- [x] My issuer icon does not include the `doctype` element.
- [x] My issuer icon directory and file name is lowercase.
- [x] My issuer icon directory and file are in the `vectors/[domain name]/` folder.
- [x] My pull request contains just one icon.
