### PR TITLE
Add Oanda Icon

### DIFF
--- a/vectors/oanda.com/oanda1.svg
+++ b/vectors/oanda.com/oanda1.svg
@@ -1,0 +1,13 @@
+<svg viewBox="564 31.149999618530273 372 368.0000305175781" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style type="text/css">
+	.st0{fill:#FFFFFF;}
+	.st1{fill:#00D37E;}
+</style>
+  </defs>
+  <g id="c" transform="matrix(0.9999999999999999, 0, 0, 0.9999999999999999, 564, 31.149999618530273)"></g>
+  <polygon class="st0" points="85.6,264.6 29,264.6 0,154.3 56.6,154.3 " style="paint-order: stroke;" transform="matrix(0.9999999999999999, 0, 0, 0.9999999999999999, 564, 31.149999618530273)"></polygon>
+  <polygon class="st1" points="326.5,169.9 269.9,169.9 315.4,0 372,0 " style="paint-order: stroke;" transform="matrix(0.9999999999999999, 0, 0, 0.9999999999999999, 564, 31.149999618530273)"></polygon>
+  <polygon class="st1" points="212.8,84.9 164.9,263.6 137,368 192.9,368 193.6,368 269.4,84.9 " style="paint-order: stroke;" transform="matrix(0.9999999999999999, 0, 0, 0.9999999999999999, 564, 31.149999618530273)"></polygon>
+  <polygon class="st0" points="146.7,196.1 90.1,196.1 135.7,368 136.4,368 192.9,368 " style="paint-order: stroke;" transform="matrix(0.9999999999999999, 0, 0, 0.9999999999999999, 564, 31.149999618530273)"></polygon>
+</svg>

--- a/vectors/oanda.com/oanda2.svg
+++ b/vectors/oanda.com/oanda2.svg
@@ -1,0 +1,13 @@
+<svg viewBox="564 31.149999618530273 372 368.0000305175781" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style type="text/css">
+	.st0{fill:#00214A;}
+	.st1{fill:#00D37E;}
+</style>
+  </defs>
+  <g id="c" transform="matrix(0.9999999999999999, 0, 0, 0.9999999999999999, 564, 31.149999618530273)"></g>
+  <polygon class="st0" points="85.6,264.6 29,264.6 0,154.3 56.6,154.3 " style="paint-order: stroke;" transform="matrix(0.9999999999999999, 0, 0, 0.9999999999999999, 564, 31.149999618530273)"></polygon>
+  <polygon class="st1" points="326.5,169.9 269.9,169.9 315.4,0 372,0 " style="paint-order: stroke;" transform="matrix(0.9999999999999999, 0, 0, 0.9999999999999999, 564, 31.149999618530273)"></polygon>
+  <polygon class="st1" points="212.8,84.9 164.9,263.6 137,368 192.9,368 193.6,368 269.4,84.9 " style="paint-order: stroke;" transform="matrix(0.9999999999999999, 0, 0, 0.9999999999999999, 564, 31.149999618530273)"></polygon>
+  <polygon class="st0" points="146.7,196.1 90.1,196.1 135.7,368 136.4,368 192.9,368 " style="paint-order: stroke;" transform="matrix(0.9999999999999999, 0, 0, 0.9999999999999999, 564, 31.149999618530273)"></polygon>
+</svg>


### PR DESCRIPTION
# Requirements

> Go over all the following points, and put an `x` in all the boxes that apply.

- [x] My issuer icon is fully vector and does not contain (parts of) a JPG/PNG/etc.
- [x] My issuer icon contains the original brand logo, not that from an icon pack.
- [x] My issuer icon is somewhat square, so it's nicely visible in the app.
- [x] My issuer icon starts and ends with the `<svg>` element.
- [x] My issuer icon is scalable (it uses `viewBox` instead of a static width/height).
- [x] My issuer icon does not contain whitespace around the SVG ([this](https://jsfiddle.net/u9x423ph/2/) JSFiddle could help to remove whitespace).
- [x] My issuer icon does not include the `doctype` element.
- [x] My issuer icon directory and file name is lowercase.
- [x] My issuer icon directory and file are in the `vectors/[domain name]/` folder.
- [x] My pull request contains just one icon.
