### PR TITLE
Update workflow tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.13'
+          python-version: '3.11'
 
       # Dependencies
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.13'
 
       # Dependencies
       - name: Install dependencies


### PR DESCRIPTION
Python 3.7 is no longer available with the latest `ubuntu-latest` runners (they switched to 24.04). I have since updated the workflows to use ~~3.13~~ 3.11 as all pull requests automatically fail because it cannot find a 3.7 runtime for Noble.

```
  Version 3.7 was not found in the local cache
  Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

When I test the script locally on my system (Arch Linux running Python 3.13.1), it works. (but 3.13 failed to build wheel on the runner for some reason, so I switched to 3.11)