### PR TITLE
add gridscale icon

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   # Validate
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
       # Environment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   # Validate
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       
       # Environment

--- a/vectors/gridscale.io/gridscale.svg
+++ b/vectors/gridscale.io/gridscale.svg
@@ -1,0 +1,11 @@
+<svg version="1.1" id="Ebene_1" x="0px" y="0px" viewBox="14.700000762939453 15.399999618530273 127.40000915527344 127.4000015258789" xml:space="preserve" sodipodi:docname="Logo_gridscale_midnightblue.svg" inkscape:version="1.3 (0e150ed, 2023-07-21)" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg"><defs id="defs1"></defs><sodipodi:namedview id="namedview1" pagecolor="#ffffff" bordercolor="#000000" borderopacity="0.25" inkscape:showpageshadow="2" inkscape:pageopacity="0.0" inkscape:pagecheckerboard="0" inkscape:deskcolor="#d1d1d1" inkscape:zoom="1.1629363" inkscape:cx="319.45001" inkscape:cy="76.960366" inkscape:window-width="2072" inkscape:window-height="1036" inkscape:window-x="2525" inkscape:window-y="580" inkscape:window-maximized="0" inkscape:current-layer="g1"></sodipodi:namedview>
+<style type="text/css" id="style1">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#15425F;}
+	.st1{fill:#15425F;}
+</style>
+<g id="g1">
+	<path id="XMLID_100_" class="st0" d="m 78.4,15.4 c -35.2,0 -63.7,28.5 -63.7,63.7 0,35.2 28.5,63.7 63.7,63.7 35.2,0 63.7,-28.5 63.7,-63.7 0,-35.2 -28.5,-63.7 -63.7,-63.7 z m -34.2,99.9 c -0.5,0 -1,-0.1 -1.4,-0.3 -1.7,-0.7 -2.8,-2.4 -2.8,-4.7 V 78.7 c 0,-4.2 3.4,-7.6 7.6,-7.6 H 70 c 1.4,0 2.6,1.2 2.6,2.6 0,1.4 -1.2,2.6 -2.6,2.6 H 47.6 c -1.3,0 -2.4,1.1 -2.4,2.4 v 30 L 93.3,60.6 h -9.4 c -1.4,0 -2.6,-1.2 -2.6,-2.6 0,-1.4 1.2,-2.6 2.6,-2.6 h 14.5 c 2,0 3.7,1.6 3.7,3.7 v 13.8 c 0,1.4 -1.2,2.6 -2.6,2.6 -1.4,0 -2.6,-1.2 -2.6,-2.6 V 64.2 L 47.1,114 c -0.8,0.8 -1.8,1.3 -2.9,1.3 z m 71,-21.9 c 0,4.9 -4,8.8 -8.8,8.8 h -20 v 7.7 c 0,4.2 -3.4,7.6 -7.6,7.6 H 58.6 c -1.4,0 -2.6,-1.2 -2.6,-2.6 0,-1.4 1.2,-2.6 2.6,-2.6 h 20.2 c 1.3,0 2.4,-1.1 2.4,-2.4 V 87.5 c 0,-1.4 1.2,-2.6 2.6,-2.6 1.4,0 2.6,1.2 2.6,2.6 v 9.6 h 20 c 2,0 3.7,-1.7 3.7,-3.7 V 51.1 c 0,-2 -1.7,-3.7 -3.7,-3.7 H 64.1 c -2,0 -3.7,1.7 -3.7,3.7 v 13.7 c 0,1.4 -1.2,2.6 -2.6,2.6 -1.4,0 -2.6,-1.2 -2.6,-2.6 V 51.1 c 0,-4.9 4,-8.8 8.8,-8.8 h 42.3 c 4.9,0 8.8,4 8.8,8.8 z"></path>
+	
+	
+</g>
+</svg>


### PR DESCRIPTION
# Requirements

> Go over all the following points, and put an `x` in all the boxes that apply.

- [x] My issuer icon is fully vector and does not contain (parts of) a JPG/PNG/etc.
- [x] My issuer icon contains the original brand logo, not that from an icon pack.
- [x] My issuer icon is somewhat square, so it's nicely visible in the app.
- [x] My issuer icon starts and ends with the `<svg>` element.
- [x] My issuer icon is scalable (it uses `viewBox` instead of a static width/height).
- [x] My issuer icon does not contain whitespace around the SVG ([this](https://jsfiddle.net/u9x423ph/2/) JSFiddle could help to remove whitespace).
- [x] My issuer icon does not include the `doctype` element.
- [x] My issuer icon directory and file name is lowercase.
- [x] My issuer icon directory and file are in the `vectors/[domain name]/` folder.
- [x] My pull request contains just one icon.
